### PR TITLE
[TS] LPS-102947 Search Permissions on resources

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/index/contributor/DDMStructureModelDocumentContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/index/contributor/DDMStructureModelDocumentContributor.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.internal.search.spi.model.index.contrib
 
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
+import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
 import com.liferay.dynamic.data.mapping.service.DDMStructureVersionLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -61,6 +62,11 @@ public class DDMStructureModelDocumentContributor
 
 			document.addKeyword(Field.STATUS, structureVersion.getStatus());
 			document.addKeyword(Field.VERSION, structureVersion.getVersion());
+
+			document.addKeyword(
+				"resourcePermissionName",
+				_ddmPermissionSupport.getStructureModelResourceName(
+					ddmStructure.getClassNameId()));
 		}
 		catch (PortalException pe) {
 			if (_log.isDebugEnabled()) {
@@ -68,8 +74,6 @@ public class DDMStructureModelDocumentContributor
 			}
 		}
 
-		document.addKeyword(
-			"resourceClassNameId", ddmStructure.getClassNameId());
 		document.addKeyword("structureKey", ddmStructure.getStructureKey());
 		document.addKeyword("storageType", ddmStructure.getStorageType());
 		document.addKeyword("type", ddmStructure.getType());
@@ -99,5 +103,8 @@ public class DDMStructureModelDocumentContributor
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DDMStructureModelDocumentContributor.class);
+
+	@Reference
+	private DDMPermissionSupport _ddmPermissionSupport;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/index/contributor/DDMStructureModelDocumentContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/index/contributor/DDMStructureModelDocumentContributor.java
@@ -62,7 +62,14 @@ public class DDMStructureModelDocumentContributor
 
 			document.addKeyword(Field.STATUS, structureVersion.getStatus());
 			document.addKeyword(Field.VERSION, structureVersion.getVersion());
+		}
+		catch (PortalException pe) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(pe, pe);
+			}
+		}
 
+		try {
 			document.addKeyword(
 				"resourcePermissionName",
 				_ddmPermissionSupport.getStructureModelResourceName(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/index/contributor/DDMTemplateModelDocumentContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/index/contributor/DDMTemplateModelDocumentContributor.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.internal.search.spi.model.index.contrib
 
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.model.DDMTemplateVersion;
+import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateVersionLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -53,6 +54,11 @@ public class DDMTemplateModelDocumentContributor
 
 			document.addKeyword(Field.STATUS, templateVersion.getStatus());
 			document.addKeyword(Field.VERSION, templateVersion.getVersion());
+
+			document.addKeyword(
+				"resourcePermissionName",
+				_ddmPermissionSupport.getTemplateModelResourceName(
+					ddmTemplate.getResourceClassNameId()));
 		}
 		catch (PortalException pe) {
 			if (_log.isDebugEnabled()) {
@@ -93,5 +99,8 @@ public class DDMTemplateModelDocumentContributor
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DDMTemplateModelDocumentContributor.class);
+
+	@Reference
+	private DDMPermissionSupport _ddmPermissionSupport;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/index/contributor/DDMTemplateModelDocumentContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/index/contributor/DDMTemplateModelDocumentContributor.java
@@ -54,7 +54,14 @@ public class DDMTemplateModelDocumentContributor
 
 			document.addKeyword(Field.STATUS, templateVersion.getStatus());
 			document.addKeyword(Field.VERSION, templateVersion.getVersion());
+		}
+		catch (PortalException pe) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(pe, pe);
+			}
+		}
 
+		try {
 			document.addKeyword(
 				"resourcePermissionName",
 				_ddmPermissionSupport.getTemplateModelResourceName(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/util/DDMSearchHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/util/DDMSearchHelper.java
@@ -17,6 +17,7 @@ package com.liferay.dynamic.data.mapping.internal.search.util;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureLayout;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -42,6 +43,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Rafael Praxedes
@@ -86,6 +88,19 @@ public class DDMSearchHelper {
 		searchContext.setAttribute(Field.CLASS_PK, classPK);
 		searchContext.setAttribute(Field.DESCRIPTION, description);
 		searchContext.setAttribute(Field.NAME, name);
+
+		try {
+			searchContext.setAttribute(
+				"resourcePermissionName",
+				_ddmPermissionSupport.getStructureModelResourceName(
+					classNameId));
+		}
+		catch (PortalException pe) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(pe, pe);
+			}
+		}
+
 		searchContext.setAttribute(Field.STATUS, status);
 		searchContext.setAttribute("storageType", storageType);
 		searchContext.setAttribute("type", type);
@@ -157,6 +172,19 @@ public class DDMSearchHelper {
 		searchContext.setAttribute("language", language);
 		searchContext.setAttribute("mode", mode);
 		searchContext.setAttribute("resourceClassNameId", resourceClassNameId);
+
+		try {
+			searchContext.setAttribute(
+				"resourcePermissionName",
+				_ddmPermissionSupport.getTemplateModelResourceName(
+					resourceClassNameId));
+		}
+		catch (PortalException pe) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(pe, pe);
+			}
+		}
+
 		searchContext.setAttribute("type", type);
 		searchContext.setCompanyId(companyId);
 		searchContext.setEnd(end);
@@ -280,5 +308,8 @@ public class DDMSearchHelper {
 		).put(
 			Field.MODIFIED_DATE, Sort.LONG_TYPE
 		).build();
+
+	@Reference
+	private DDMPermissionSupport _ddmPermissionSupport;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMTemplateLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMTemplateLocalServiceTest.java
@@ -280,6 +280,29 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 	}
 
 	@Test
+	public void testSearchByNameAndDescription1ResourcePermission()
+		throws Exception {
+
+		addDisplayTemplate(
+			_classNameId, 0, _resourceClassNameId, "Event", "Event",
+			WorkflowConstants.STATUS_APPROVED);
+		addDisplayTemplate(
+			_classNameId, 0, _resourceClassNameId, "Contact", "Contact",
+			WorkflowConstants.STATUS_APPROVED);
+		addDisplayTemplate(
+			_classNameId, 0, _resourceClassNameId, "Meeting", "Meeting",
+			WorkflowConstants.STATUS_APPROVED);
+
+		List<DDMTemplate> templates = DDMTemplateLocalServiceUtil.search(
+			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
+			null, null, _resourceClassNameId, "Event", "Meeting", null, null,
+			null, WorkflowConstants.STATUS_APPROVED, true, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+
+		Assert.assertEquals(templates.toString(), 2, templates.size());
+	}
+
+	@Test
 	public void testSearchByNameAndDescription2() throws Exception {
 		addDisplayTemplate(
 			_classNameId, 0, _resourceClassNameId, "Event", "Event",
@@ -448,6 +471,25 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 	}
 
 	@Test
+	public void testSearchCountByKeywordsResourcePermission() throws Exception {
+		int initialCount = DDMTemplateLocalServiceUtil.searchCount(
+			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
+			_resourceClassNameId, "Test", null, null,
+			WorkflowConstants.STATUS_APPROVED);
+
+		addDisplayTemplate(
+			_classNameId, 0, _resourceClassNameId, "Test Template",
+			"Test Template", WorkflowConstants.STATUS_APPROVED);
+
+		int count = DDMTemplateLocalServiceUtil.searchCount(
+			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
+			_resourceClassNameId, "Test", null, null,
+			WorkflowConstants.STATUS_APPROVED);
+
+		Assert.assertEquals(initialCount + 1, count);
+	}
+
+	@Test
 	public void testSearchCountByLanguage() throws Exception {
 		String velocityLanguage = TemplateConstants.LANG_TYPE_VM;
 
@@ -497,6 +539,25 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 			WorkflowConstants.STATUS_APPROVED);
 
 		Assert.assertEquals(3, count);
+	}
+
+	@Test
+	public void testSearchCountResourcePermission() throws Exception {
+		int initialCount = DDMTemplateLocalServiceUtil.searchCount(
+			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
+			_resourceClassNameId, "Test Template", null, null, null, null,
+			WorkflowConstants.STATUS_APPROVED, false);
+
+		addDisplayTemplate(
+			_classNameId, 0, _resourceClassNameId, "Test Template",
+			"Test Template", WorkflowConstants.STATUS_APPROVED);
+
+		int count = DDMTemplateLocalServiceUtil.searchCount(
+			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
+			_resourceClassNameId, "Test Template", null, null, null, null,
+			WorkflowConstants.STATUS_APPROVED, false);
+
+		Assert.assertEquals(initialCount + 1, count);
 	}
 
 	@Test

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMTemplateLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMTemplateLocalServiceTest.java
@@ -272,29 +272,6 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 
 		List<DDMTemplate> templates = DDMTemplateLocalServiceUtil.search(
 			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
-			null, null, 0, "Event", "Meeting", null, null, null,
-			WorkflowConstants.STATUS_APPROVED, true, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS, null);
-
-		Assert.assertEquals(templates.toString(), 2, templates.size());
-	}
-
-	@Test
-	public void testSearchByNameAndDescription1ResourcePermission()
-		throws Exception {
-
-		addDisplayTemplate(
-			_classNameId, 0, _resourceClassNameId, "Event", "Event",
-			WorkflowConstants.STATUS_APPROVED);
-		addDisplayTemplate(
-			_classNameId, 0, _resourceClassNameId, "Contact", "Contact",
-			WorkflowConstants.STATUS_APPROVED);
-		addDisplayTemplate(
-			_classNameId, 0, _resourceClassNameId, "Meeting", "Meeting",
-			WorkflowConstants.STATUS_APPROVED);
-
-		List<DDMTemplate> templates = DDMTemplateLocalServiceUtil.search(
-			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
 			null, null, _resourceClassNameId, "Event", "Meeting", null, null,
 			null, WorkflowConstants.STATUS_APPROVED, true, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
@@ -328,7 +305,7 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 	public void testSearchCount() throws Exception {
 		int initialCount = DDMTemplateLocalServiceUtil.searchCount(
 			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
-			0, "Test Template", null, null, null, null,
+			_resourceClassNameId, "Test Template", null, null, null, null,
 			WorkflowConstants.STATUS_APPROVED, false);
 
 		addDisplayTemplate(
@@ -456,24 +433,6 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 	public void testSearchCountByKeywords() throws Exception {
 		int initialCount = DDMTemplateLocalServiceUtil.searchCount(
 			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
-			0, null, null, null, WorkflowConstants.STATUS_APPROVED);
-
-		addDisplayTemplate(
-			_classNameId, 0, _resourceClassNameId, "Test Template",
-			"Test Template", WorkflowConstants.STATUS_APPROVED);
-
-		int count = DDMTemplateLocalServiceUtil.searchCount(
-			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
-			_resourceClassNameId, "Test", null, null,
-			WorkflowConstants.STATUS_APPROVED);
-
-		Assert.assertEquals(initialCount + 1, count);
-	}
-
-	@Test
-	public void testSearchCountByKeywordsResourcePermission() throws Exception {
-		int initialCount = DDMTemplateLocalServiceUtil.searchCount(
-			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
 			_resourceClassNameId, "Test", null, null,
 			WorkflowConstants.STATUS_APPROVED);
 
@@ -542,22 +501,52 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 	}
 
 	@Test
-	public void testSearchCountResourcePermission() throws Exception {
-		int initialCount = DDMTemplateLocalServiceUtil.searchCount(
-			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
-			_resourceClassNameId, "Test Template", null, null, null, null,
-			WorkflowConstants.STATUS_APPROVED, false);
+	public void testSearchCountMissingResourceClassNameId() throws Exception {
+		try {
+			DDMTemplateLocalServiceUtil.searchCount(
+				TestPropsValues.getCompanyId(), group.getGroupId(),
+				_classNameId, 0, 0, null, null, null,
+				WorkflowConstants.STATUS_APPROVED);
 
-		addDisplayTemplate(
-			_classNameId, 0, _resourceClassNameId, "Test Template",
-			"Test Template", WorkflowConstants.STATUS_APPROVED);
+			Assert.fail();
+		}
+		catch (RuntimeException re) {
+			Assert.assertEquals(
+				"Unable to get class name from id 0", re.getMessage());
+		}
+	}
 
-		int count = DDMTemplateLocalServiceUtil.searchCount(
-			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
-			_resourceClassNameId, "Test Template", null, null, null, null,
-			WorkflowConstants.STATUS_APPROVED, false);
+	@Test
+	public void testSearchCountMissingResourceClassNameId2() throws Exception {
+		try {
+			DDMTemplateLocalServiceUtil.searchCount(
+				TestPropsValues.getCompanyId(), group.getGroupId(),
+				_classNameId, 0, 0, "Test Template", null, null, null, null,
+				WorkflowConstants.STATUS_APPROVED, false);
 
-		Assert.assertEquals(initialCount + 1, count);
+			Assert.fail();
+		}
+		catch (RuntimeException re) {
+			Assert.assertEquals(
+				"Unable to get class name from id 0", re.getMessage());
+		}
+	}
+
+	@Test
+	public void testSearchMissingResourceClassNameId() throws Exception {
+		try {
+			DDMTemplateLocalServiceUtil.search(
+				TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
+				null, null, 0, "Event", "Meeting", null, null, null,
+				WorkflowConstants.STATUS_APPROVED, true, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+			Assert.fail();
+		}
+		catch (RuntimeException re) {
+			Assert.assertEquals(
+				"Unable to get class name from id 0", re.getMessage());
+		}
 	}
 
 	@Test

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMTemplateLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMTemplateLocalServiceTest.java
@@ -272,8 +272,8 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 
 		List<DDMTemplate> templates = DDMTemplateLocalServiceUtil.search(
 			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
-			null, null, _resourceClassNameId, "Event", "Meeting", null, null,
-			null, WorkflowConstants.STATUS_APPROVED, true, QueryUtil.ALL_POS,
+			null, null, 0, "Event", "Meeting", null, null, null,
+			WorkflowConstants.STATUS_APPROVED, true, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 
 		Assert.assertEquals(templates.toString(), 2, templates.size());
@@ -305,7 +305,7 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 	public void testSearchCount() throws Exception {
 		int initialCount = DDMTemplateLocalServiceUtil.searchCount(
 			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
-			_resourceClassNameId, "Test Template", null, null, null, null,
+			0, "Test Template", null, null, null, null,
 			WorkflowConstants.STATUS_APPROVED, false);
 
 		addDisplayTemplate(
@@ -433,8 +433,7 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 	public void testSearchCountByKeywords() throws Exception {
 		int initialCount = DDMTemplateLocalServiceUtil.searchCount(
 			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
-			_resourceClassNameId, "Test", null, null,
-			WorkflowConstants.STATUS_APPROVED);
+			0, null, null, null, WorkflowConstants.STATUS_APPROVED);
 
 		addDisplayTemplate(
 			_classNameId, 0, _resourceClassNameId, "Test Template",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMTemplateLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMTemplateLocalServiceTest.java
@@ -272,8 +272,8 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 
 		List<DDMTemplate> templates = DDMTemplateLocalServiceUtil.search(
 			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
-			null, null, 0, "Event", "Meeting", null, null, null,
-			WorkflowConstants.STATUS_APPROVED, true, QueryUtil.ALL_POS,
+			null, null, _resourceClassNameId, "Event", "Meeting", null, null,
+			null, WorkflowConstants.STATUS_APPROVED, true, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 
 		Assert.assertEquals(templates.toString(), 2, templates.size());
@@ -305,7 +305,7 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 	public void testSearchCount() throws Exception {
 		int initialCount = DDMTemplateLocalServiceUtil.searchCount(
 			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
-			0, "Test Template", null, null, null, null,
+			_resourceClassNameId, "Test Template", null, null, null, null,
 			WorkflowConstants.STATUS_APPROVED, false);
 
 		addDisplayTemplate(
@@ -433,7 +433,8 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 	public void testSearchCountByKeywords() throws Exception {
 		int initialCount = DDMTemplateLocalServiceUtil.searchCount(
 			TestPropsValues.getCompanyId(), group.getGroupId(), _classNameId, 0,
-			0, null, null, null, WorkflowConstants.STATUS_APPROVED);
+			_resourceClassNameId, "Test", null, null,
+			WorkflowConstants.STATUS_APPROVED);
 
 		addDisplayTemplate(
 			_classNameId, 0, _resourceClassNameId, "Test Template",

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
@@ -20,7 +20,6 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.NoSuchResourceException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -41,9 +40,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.security.permission.UserBag;
-import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -235,9 +232,6 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 	}
 
 	@Reference
-	protected ClassNameLocalService classNameLocalService;
-
-	@Reference
 	protected GroupLocalService groupLocalService;
 
 	@Reference
@@ -250,9 +244,6 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 
 	@Reference
 	protected Portal portal;
-
-	@Reference
-	protected ResourceActions resourceActions;
 
 	@Reference
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
@@ -511,17 +502,9 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 		searchContext.setAttribute(
 			"searchPermissionContext", searchPermissionContext);
 
-		ClassName resourceClassName = classNameLocalService.fetchClassName(
-			GetterUtil.getLong(
-				searchContext.getAttribute("resourceClassNameId")));
-
-		if (resourceClassName != null) {
-			className = resourceActions.getCompositeModelName(
-				className, resourceClassName.getClassName());
-		}
-
 		return _getPermissionFilter(
-			companyId, searchGroupIds, userId, permissionChecker, className,
+			companyId, searchGroupIds, userId, permissionChecker,
+			_getPermissionName(searchContext, className),
 			searchPermissionContext);
 	}
 
@@ -618,6 +601,13 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 		}
 
 		return booleanFilter;
+	}
+
+	private String _getPermissionName(
+		SearchContext searchContext, String defaultValue) {
+
+		return GetterUtil.getString(
+			searchContext.getAttribute("resourcePermissionName"), defaultValue);
 	}
 
 	private static final String _NULL_SEARCH_PERMISSION_CONTEXT =

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerDocumentBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerDocumentBuilderImpl.java
@@ -20,8 +20,10 @@ import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentContributor;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.search.indexer.BaseModelDocumentFactory;
 import com.liferay.portal.search.indexer.IndexerDocumentBuilder;
+import com.liferay.portal.search.permission.SearchPermissionDocumentContributor;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
 /**
@@ -33,12 +35,16 @@ public class IndexerDocumentBuilderImpl implements IndexerDocumentBuilder {
 		BaseModelDocumentFactory baseModelDocumentFactory,
 		Iterable<ModelDocumentContributor> modelDocumentContributors,
 		Iterable<DocumentContributor> documentContributors,
-		IndexerPostProcessorsHolder indexerPostProcessorsHolder) {
+		IndexerPostProcessorsHolder indexerPostProcessorsHolder,
+		SearchPermissionDocumentContributor
+			searchPermissionDocumentContributor) {
 
 		_baseModelDocumentFactory = baseModelDocumentFactory;
 		_modelDocumentContributors = modelDocumentContributors;
 		_documentContributors = documentContributors;
 		_indexerPostProcessorsHolder = indexerPostProcessorsHolder;
+		_searchPermissionDocumentContributor =
+			searchPermissionDocumentContributor;
 	}
 
 	@Override
@@ -52,6 +58,9 @@ public class IndexerDocumentBuilderImpl implements IndexerDocumentBuilder {
 		_modelDocumentContributors.forEach(
 			(ModelDocumentContributor modelDocumentContributor) ->
 				modelDocumentContributor.contribute(document, baseModel));
+
+		_searchPermissionDocumentContributor.addPermissionFields(
+			GetterUtil.getLong(document.get(Field.COMPANY_ID)), document);
 
 		postProcessDocument(document, baseModel);
 
@@ -90,5 +99,7 @@ public class IndexerDocumentBuilderImpl implements IndexerDocumentBuilder {
 	private final Iterable<DocumentContributor> _documentContributors;
 	private final IndexerPostProcessorsHolder _indexerPostProcessorsHolder;
 	private final Iterable<ModelDocumentContributor> _modelDocumentContributors;
+	private final SearchPermissionDocumentContributor
+		_searchPermissionDocumentContributor;
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchConfiguratorServiceTrackerCustomizer.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchConfiguratorServiceTrackerCustomizer.java
@@ -45,6 +45,7 @@ import com.liferay.portal.search.indexer.IndexerSearcher;
 import com.liferay.portal.search.indexer.IndexerSummaryBuilder;
 import com.liferay.portal.search.indexer.IndexerWriter;
 import com.liferay.portal.search.internal.searcher.IndexSearcherHelper;
+import com.liferay.portal.search.permission.SearchPermissionDocumentContributor;
 import com.liferay.portal.search.permission.SearchPermissionIndexWriter;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.portal.search.spi.model.query.contributor.QueryConfigContributor;
@@ -203,7 +204,8 @@ public class ModelSearchConfiguratorServiceTrackerCustomizer
 		IndexerDocumentBuilder indexerDocumentBuilder =
 			new IndexerDocumentBuilderImpl(
 				baseModelDocumentFactory, modelDocumentContributors,
-				documentContributors, indexerPostProcessorsHolder);
+				documentContributors, indexerPostProcessorsHolder,
+				searchPermissionDocumentContributor);
 
 		ServiceRegistration<IndexerDocumentBuilder>
 			indexerDocumentBuilderServiceRegistration =
@@ -348,6 +350,10 @@ public class ModelSearchConfiguratorServiceTrackerCustomizer
 
 	@Reference
 	protected RelatedEntryIndexerRegistry relatedEntryIndexerRegistry;
+
+	@Reference
+	protected SearchPermissionDocumentContributor
+		searchPermissionDocumentContributor;
 
 	@Reference
 	protected SearchPermissionIndexWriter searchPermissionIndexWriter;

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionDocumentContributorImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionDocumentContributorImpl.java
@@ -19,7 +19,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchResourceException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
@@ -28,8 +27,6 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.ResourceActions;
-import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -138,17 +135,11 @@ public class SearchPermissionDocumentContributorImpl
 				document, className, classPK);
 		}
 
+		String permissionName = _getPermissionName(document, className);
+
 		try {
-			ClassName resourceClassName = _classNameLocalService.fetchClassName(
-				GetterUtil.getLong(document.get("resourceClassNameId")));
-
-			if (resourceClassName != null) {
-				className = _resourceActions.getCompositeModelName(
-					className, resourceClassName.getClassName());
-			}
-
 			List<Role> roles = _resourcePermissionLocalService.getRoles(
-				companyId, className, ResourceConstants.SCOPE_INDIVIDUAL,
+				companyId, permissionName, ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(classPK), viewActionId);
 
 			if (roles.isEmpty()) {
@@ -184,26 +175,25 @@ public class SearchPermissionDocumentContributorImpl
 				_log.warn(
 					StringBundler.concat(
 						"Unable to get permission fields for class name ",
-						className, " and class PK ", classPK),
+						permissionName, " and class PK ", classPK),
 					e);
 			}
 		}
+	}
+
+	private String _getPermissionName(Document document, String defaultValue) {
+		return GetterUtil.getString(
+			document.get("resourcePermissionName"), defaultValue);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SearchPermissionDocumentContributorImpl.class);
 
 	@Reference
-	private ClassNameLocalService _classNameLocalService;
-
-	@Reference
 	private IndexerRegistry _indexerRegistry;
 
 	@Reference
 	private Portal _portal;
-
-	@Reference
-	private ResourceActions _resourceActions;
 
 	@Reference
 	private ResourcePermissionLocalService _resourcePermissionLocalService;

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/SearchPermissionCheckerImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/SearchPermissionCheckerImplTest.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.search.SearchPermissionChecker;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.UserBag;
-import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -87,7 +86,6 @@ public class SearchPermissionCheckerImplTest {
 	protected SearchPermissionCheckerImpl createSearchPermissionChecker() {
 		return new SearchPermissionCheckerImpl() {
 			{
-				classNameLocalService = _classNameLocalService;
 				indexerRegistry = _indexerRegistry;
 				permissionChecker = _permissionChecker;
 				resourcePermissionLocalService =
@@ -133,9 +131,6 @@ public class SearchPermissionCheckerImplTest {
 			_user
 		).getUserId();
 	}
-
-	@Mock
-	private ClassNameLocalService _classNameLocalService;
 
 	@Mock
 	private Indexer _indexer;


### PR DESCRIPTION
@rodrigopaulino Please see 997d88b - I think a new regression test for this bug would be really important, as we have changes planned for the Search Permissions framework soon - existing tests seem to pass with or without this fix.

Also see https://github.com/rodrigopaulino/liferay-portal/commit/119e9ad2d3971c3e3cb6f99a25195141be962b8e - just make sure this API behavior change (now throws an exception) is really what DDM would want. Perhaps there's a way to gracefully degrade to the original behavior in case this argument is missing?

In any case thanks for this fix, I certainly learned a lot from it!! 😃 