### PR TITLE
LPS 127725

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldValueRequestParameterRetriever.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldValueRequestParameterRetriever.java
@@ -16,10 +16,12 @@ package com.liferay.dynamic.data.mapping.form.field.type.internal.checkbox.multi
 
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueRequestParameterRetriever;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -54,7 +56,11 @@ public class CheckboxMultipleDDMFormFieldValueRequestParameterRetriever
 			getDefaultDDMFormFieldParameterValues(
 				defaultDDMFormFieldParameterValue));
 
-		return jsonFactory.serialize(parameterValues);
+		if (ArrayUtil.isNotEmpty(parameterValues)) {
+			return jsonFactory.serialize(parameterValues);
+		}
+
+		return StringPool.BLANK;
 	}
 
 	protected String[] getDefaultDDMFormFieldParameterValues(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRequestParameterRetriever.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRequestParameterRetriever.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.form.field.type.internal.grid;
 
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueRequestParameterRetriever;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -51,7 +52,7 @@ public class GridDDMFormFieldValueRequestParameterRetriever
 			httpServletRequest.getParameterMap();
 
 		if (!parameterMap.containsKey(ddmFormFieldParameterName)) {
-			return jsonObject.toString();
+			return StringPool.BLANK;
 		}
 
 		String[] parameterValues = parameterMap.get(ddmFormFieldParameterName);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRequestParameterRetriever.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRequestParameterRetriever.java
@@ -59,7 +59,8 @@ public class GridDDMFormFieldValueRequestParameterRetriever
 
 		if (parameterValues.length == 1) {
 			try {
-				jsonObject = jsonFactory.createJSONObject(parameterValues[0]);
+				jsonObject = jsonFactory.createJSONObject(
+					(String)jsonFactory.deserialize(parameterValues[0]));
 
 				return jsonObject.toString();
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/radio/RadioDDMFormFieldValueRequestParameterRetriever.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/radio/RadioDDMFormFieldValueRequestParameterRetriever.java
@@ -16,12 +16,14 @@ package com.liferay.dynamic.data.mapping.form.field.type.internal.radio;
 
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueRequestParameterRetriever;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -48,7 +50,14 @@ public class RadioDDMFormFieldValueRequestParameterRetriever
 			ddmFormFieldParameterName);
 
 		if (parameterValue == null) {
-			return getPredefinedValue(defaultDDMFormFieldParameterValue);
+			parameterValue = getPredefinedValue(
+				defaultDDMFormFieldParameterValue);
+
+			if (Validator.isNotNull(parameterValue)) {
+				return parameterValue;
+			}
+
+			return StringPool.BLANK;
 		}
 
 		return GetterUtil.getString(parameterValue);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldValueRequestParameterRetriever.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldValueRequestParameterRetriever.java
@@ -16,9 +16,11 @@ package com.liferay.dynamic.data.mapping.form.field.type.internal.select;
 
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueRequestParameterRetriever;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -52,7 +54,11 @@ public class SelectDDMFormFieldValueRequestParameterRetriever
 			getDefaultDDMFormFieldParameterValues(
 				defaultDDMFormFieldParameterValue));
 
-		return jsonFactory.serialize(parameterValues);
+		if (ArrayUtil.isNotEmpty(parameterValues)) {
+			return jsonFactory.serialize(parameterValues);
+		}
+
+		return StringPool.BLANK;
 	}
 
 	protected String[] getDefaultDDMFormFieldParameterValues(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Grid/Grid.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Grid/Grid.es.js
@@ -14,9 +14,10 @@
 
 import {ClayInput, ClayRadio} from '@clayui/form';
 import ClayTable from '@clayui/table';
-import React, {useState} from 'react';
+import React from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
+import {useSyncValue} from '../hooks/useSyncValue.es';
 
 const TableHead = ({columns}) => (
 	<ClayTable.Head>
@@ -139,7 +140,7 @@ const Main = ({
 	value = {},
 	...otherProps
 }) => {
-	const [state, setState] = useState(value);
+	const [state, setState] = useSyncValue(value, false);
 
 	return (
 		<FieldBase name={name} readOnly={readOnly} {...otherProps}>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldValueRequestParameterRetrieverTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldValueRequestParameterRetrieverTest.java
@@ -68,7 +68,7 @@ public class CheckboxMultipleDDMFormFieldValueRequestParameterRetrieverTest {
 
 	@Test
 	public void testEmptySubmission() {
-		String expectedResult = "[]";
+		String expectedResult = "";
 
 		String defaultDDMFormFieldParameterValue = createJSONArrayString(
 			"Option 1");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRequestParameterRetrieverTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRequestParameterRetrieverTest.java
@@ -122,7 +122,7 @@ public class GridDDMFormFieldValueRequestParameterRetrieverTest {
 				new MockHttpServletRequest(), _PARAMETER_NAME,
 				StringPool.BLANK);
 
-		Assert.assertEquals("{}", parameterValue);
+		Assert.assertEquals("", parameterValue);
 	}
 
 	private void _setUpJSONFactoryUtil() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Grid/Grid.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Grid/Grid.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {act, cleanup, fireEvent, render} from '@testing-library/react';
+import {cleanup, fireEvent, render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {PageProvider} from 'dynamic-data-mapping-form-renderer';
 import React from 'react';
@@ -49,7 +49,6 @@ describe('Grid', () => {
 	afterEach(cleanup);
 
 	beforeEach(() => {
-		jest.useFakeTimers();
 		fetch.mockResponseOnce(JSON.stringify({}));
 	});
 
@@ -70,10 +69,6 @@ describe('Grid', () => {
 			/>
 		);
 
-		act(() => {
-			jest.runAllTimers();
-		});
-
 		expect(container).toMatchSnapshot();
 	});
 
@@ -81,10 +76,6 @@ describe('Grid', () => {
 		const {container} = render(
 			<GridWithProvider columns={[]} spritemap={spritemap} />
 		);
-
-		act(() => {
-			jest.runAllTimers();
-		});
 
 		expect(container).toMatchSnapshot();
 	});
@@ -94,10 +85,6 @@ describe('Grid', () => {
 			<GridWithProvider readOnly={true} spritemap={spritemap} />
 		);
 
-		act(() => {
-			jest.runAllTimers();
-		});
-
 		expect(container).toMatchSnapshot();
 	});
 
@@ -105,10 +92,6 @@ describe('Grid', () => {
 		const {container} = render(
 			<GridWithProvider spritemap={spritemap} tip="Type something" />
 		);
-
-		act(() => {
-			jest.runAllTimers();
-		});
 
 		expect(container).toMatchSnapshot();
 	});
@@ -118,10 +101,6 @@ describe('Grid', () => {
 			<GridWithProvider id="Id" spritemap={spritemap} />
 		);
 
-		act(() => {
-			jest.runAllTimers();
-		});
-
 		expect(container).toMatchSnapshot();
 	});
 
@@ -130,10 +109,6 @@ describe('Grid', () => {
 			<GridWithProvider label="label" spritemap={spritemap} />
 		);
 
-		act(() => {
-			jest.runAllTimers();
-		});
-
 		expect(container).toMatchSnapshot();
 	});
 
@@ -141,10 +116,6 @@ describe('Grid', () => {
 		const {container} = render(
 			<GridWithProvider required={false} spritemap={spritemap} />
 		);
-
-		act(() => {
-			jest.runAllTimers();
-		});
 
 		expect(container).toMatchSnapshot();
 	});
@@ -166,10 +137,6 @@ describe('Grid', () => {
 			/>
 		);
 
-		act(() => {
-			jest.runAllTimers();
-		});
-
 		expect(container).toMatchSnapshot();
 	});
 
@@ -178,10 +145,6 @@ describe('Grid', () => {
 			<GridWithProvider rows={[]} spritemap={spritemap} />
 		);
 
-		act(() => {
-			jest.runAllTimers();
-		});
-
 		expect(container).toMatchSnapshot();
 	});
 
@@ -189,10 +152,6 @@ describe('Grid', () => {
 		const {container} = render(
 			<GridWithProvider label="text" showLabel spritemap={spritemap} />
 		);
-
-		act(() => {
-			jest.runAllTimers();
-		});
 
 		expect(container).toMatchSnapshot();
 	});
@@ -235,10 +194,6 @@ describe('Grid', () => {
 
 		fireEvent.blur(radioInputElement);
 
-		act(() => {
-			jest.runAllTimers();
-		});
-
 		expect(handleFieldBlurred).toHaveBeenCalled();
 	});
 
@@ -280,10 +235,6 @@ describe('Grid', () => {
 
 		userEvent.click(radioInputElement);
 
-		act(() => {
-			jest.runAllTimers();
-		});
-
 		expect(handleFieldEdited).toHaveBeenCalled();
 	});
 
@@ -324,10 +275,6 @@ describe('Grid', () => {
 		);
 
 		fireEvent.focus(radioInputElement);
-
-		act(() => {
-			jest.runAllTimers();
-		});
 
 		expect(handleFieldFocused).toHaveBeenCalled();
 	});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/reducers/defaultReducer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/reducers/defaultReducer.es.js
@@ -69,6 +69,11 @@ export default (state, action) => {
 								}
 							}
 
+							try {
+								_value = JSON.parse(_value);
+							}
+							catch (e) {}
+
 							return {
 								value: _value,
 							};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/setDataRecord.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/setDataRecord.es.js
@@ -49,16 +49,6 @@ export default (
 
 		let availableLanguageIds;
 
-		Object.keys(localizedValue)
-			.filter(
-				(languageId) =>
-					!localizedValueEdited?.[languageId] &&
-					localizedValue[languageId] === ''
-			)
-			.forEach((languageId) => {
-				delete localizedValue[languageId];
-			});
-
 		if (localizedValue) {
 			availableLanguageIds = Object.keys(localizedValue);
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/setDataRecord.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/setDataRecord.es.js
@@ -36,7 +36,7 @@ export default (
 		return;
 	}
 
-	let _value = value;
+	let _value = JSON.stringify(value);
 
 	if (!visible) {
 		_value = '';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-values-factory/src/main/java/com/liferay/dynamic/data/mapping/form/values/factory/internal/DDMFormValuesFactoryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-values-factory/src/main/java/com/liferay/dynamic/data/mapping/form/values/factory/internal/DDMFormValuesFactoryImpl.java
@@ -382,8 +382,9 @@ public class DDMFormValuesFactoryImpl implements DDMFormValuesFactory {
 			DDMFormRendererConstants.DDM_FORM_FIELD_LANGUAGE_ID_SEPARATOR);
 		sb.append(LocaleUtil.toLanguageId(locale));
 
-		if (Validator.isNull(
-				ParamUtil.getString(httpServletRequest, sb.toString()))) {
+		if (ArrayUtil.isEmpty(
+				ParamUtil.getParameterValues(
+					httpServletRequest, sb.toString()))) {
 
 			sb.setIndex(sb.index() - 1);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-values-factory/src/main/java/com/liferay/dynamic/data/mapping/form/values/factory/internal/DDMFormValuesFactoryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-values-factory/src/main/java/com/liferay/dynamic/data/mapping/form/values/factory/internal/DDMFormValuesFactoryImpl.java
@@ -486,7 +486,9 @@ public class DDMFormValuesFactoryImpl implements DDMFormValuesFactory {
 				httpServletRequest, fieldType, ddmFormFieldParameterName,
 				predefinedValue.getString(availableLocale), availableLocale);
 
-			value.addString(availableLocale, ddmFormFieldParameterValue);
+			if (Validator.isNotNull(ddmFormFieldParameterValue)) {
+				value.addString(availableLocale, ddmFormFieldParameterValue);
+			}
 		}
 
 		ddmFormFieldValue.setValue(value);
@@ -511,9 +513,10 @@ public class DDMFormValuesFactoryImpl implements DDMFormValuesFactory {
 			httpServletRequest, fieldType, ddmFormFieldParameterName,
 			predefinedValue.getString(defaultLocale), defaultLocale);
 
-		Value value = new UnlocalizedValue(ddmFormFieldParameterValue);
-
-		ddmFormFieldValue.setValue(value);
+		if (Validator.isNotNull(ddmFormFieldParameterValue)) {
+			ddmFormFieldValue.setValue(
+				new UnlocalizedValue(ddmFormFieldParameterValue));
+		}
 	}
 
 	protected void setDDMFormValuesAvailableLocales(


### PR DESCRIPTION
- LPS-127725 Stringify every value from the data record before the request is made
- LPS-127725 Use syncvalue hook so that new prop values will update the component state
- LPS-127725 Remove jest timers as they are not being used here
- LPS-127725 Verify if the request contains the parameter
- LPS-127725 Don't create blank values for every available language if it wasn't retrieved by the request
- LPS-127725 Change expected behavior of unit tests
- LPS-127725 Parse values if they are stringified JSON objects
- LPS-127725 Some parameters need to be deserialized before creating the JSONObject, because they are hidden inputs in the DOM
